### PR TITLE
Replace haxelib:hxWidgets usage for lix support

### DIFF
--- a/Build.xml
+++ b/Build.xml
@@ -8,7 +8,7 @@
         <files id="haxe">
             <compilerflag value="-I${WXWIN}\include" />
             <compilerflag value="-I${WXWIN}\lib\${lib_folder}\mswu" />
-            <compilerflag value="-I${haxelib:hxWidgets}\include" />
+            <compilerflag value="-I${HXWIDGETS_PATH}\include" />
             <compilerflag value="-DUNICODE" />
             <compilerflag value="-D_UNICODE" />
             <compilerflag value="-DwxMSVC_VERISON_AUTO" />
@@ -19,7 +19,7 @@
 
             <compilerflag value="-DWXUSINGDLL" unless="WXSTATIC"/>
 
-            <file name="${haxelib:hxWidgets}\include\custom\wxownerdrawnpanel.cpp" />
+            <file name="${HXWIDGETS_PATH}\include\custom\wxownerdrawnpanel.cpp" />
         </files>
 
         <target id="haxe" tool="linker" toolid="exe">


### PR DESCRIPTION
Hello,
Mentioned not too long ago in the discord channel that hxWidgets doesn't work with lix, and that it seemed to be related to the `haxelib:` usage. With 1.0 out I decided to take another look and get a fix working!
This replaces all `haxelib:` usage with a custom `HXWIDGETS_PATH` define which points to the root of the library, the way this is calculated is the same way all the linc libraries do it.

I've tested this with Windows and Linux with the haxeui component examples and it works fine (this repos hxwidget samples fail a wxwidget assert on launch though).

Cheers.