### PR TITLE
Update vcvarsall.bat example location

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You need the [hxcpp](https://lib.haxe.org/p/hxcpp) library and **at least Haxe 3
 * Download and install wxWidgets using installer from [https://www.wxwidgets.org/downloads/](https://www.wxwidgets.org/downloads/)
 * Create `WXWIN` environment var if setup didnt (eg: `C:\wxWidgets-3.0.2`)
 * Run `vcvarsall.bat` from Visual Studio dir
-  (eg: `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"`)
+  (eg: `"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat"`)
 * Build shared and static releases of wxWidgets:
   * `cd %WXWIN%\build\msw\`
   * `nmake.exe -f makefile.vc BUILD=release`


### PR DESCRIPTION
I tried using the example location, but it didn't work because the path was pointing to the old location. I've updated the example path to point to the new location that is used by Visual Studio 2022. The path is specific to the community edition, but it's an example, so I don't think that needs to be stated explicitly.