### PR TITLE
Taskbar events

### DIFF
--- a/samples/00-Showcase/src/Main.hx
+++ b/samples/00-Showcase/src/Main.hx
@@ -56,6 +56,16 @@ class Main {
 
         var taskBarIcon = new TaskBarIcon();
         taskBarIcon.setBitmap(Bitmap.fromHaxeResource("haxe-logo-tiny.png"), "Some tooltip");
+
+        var taskBarMenu = new Menu();
+        taskBarMenu.append(1101, "Item 1");
+        taskBarMenu.append(1102, "Item 2");
+        taskBarMenu.appendSeparator();
+        taskBarMenu.append(1103, "Item 3");
+
+        taskBarIcon.bind(EventType.TASKBAR_CLICK, (event) -> {
+            frame.popupMenu(taskBarMenu);
+        });
         
         var platform:PlatformInfo  = new PlatformInfo();
         if (platform.isWindows) {

--- a/src/wx/widgets/EventType.hx
+++ b/src/wx/widgets/EventType.hx
@@ -14,6 +14,7 @@ package wx.widgets;
 #include <wx/calctrl.h>
 #include <wx/dataview.h>
 #include <wx/treebase.h>
+#include <wx/taskbar.h>
 ")
 
 class EventType {
@@ -80,4 +81,13 @@ class EventType {
 
     public static var THREAD:Int                = untyped __cpp__("wxEVT_THREAD");
     public static var END_PROCESS:Int           = untyped __cpp__("wxEVT_END_PROCESS");
+
+    public static var TASKBAR_CLICK:Int         = untyped __cpp__("wxEVT_TASKBAR_CLICK");
+    public static var TASKBAR_LEFT_DCLICK:Int   = untyped __cpp__("wxEVT_TASKBAR_LEFT_DCLICK");
+    public static var TASKBAR_LEFT_DOWN:Int     = untyped __cpp__("wxEVT_TASKBAR_LEFT_DOWN");
+    public static var TASKBAR_LEFT_UP:Int       = untyped __cpp__("wxEVT_TASKBAR_LEFT_UP");
+    public static var TASKBAR_MOVE:Int          = untyped __cpp__("wxEVT_TASKBAR_MOVE");
+    public static var TASKBAR_RIGHT_DCLICK:Int  = untyped __cpp__("wxEVT_TASKBAR_RIGHT_DCLICK");
+    public static var TASKBAR_RIGHT_DOWN:Int    = untyped __cpp__("wxEVT_TASKBAR_RIGHT_DOWN");
+    public static var TASKBAR_RIGHT_UP:Int      = untyped __cpp__("wxEVT_TASKBAR_RIGHT_UP");
 }


### PR DESCRIPTION
Added [`TASKBAR_*`](https://docs.wxwidgets.org/3.2/taskbar_8h.html) event constants to `EventType`. These events allow handling taskbar icon/tray icon events such as click to open popup menu (as added to the showcase).

There's also [wxTaskBarIconEvent](https://docs.wxwidgets.org/3.2/classwx_task_bar_icon_event.html) that I didn't add extern for as it didn't seem necessary (I can add it if wanted, though).