### PR TITLE
Corrects button bar with button that has an icon

### DIFF
--- a/src/hx/widgets/AnyButton.hx
+++ b/src/hx/widgets/AnyButton.hx
@@ -24,7 +24,6 @@ class AnyButton extends Control {
         anyButtonRef.ptr.setBitmap(value.bitmapRef.ref);
         if (!_hasBitmap) {
             _hasBitmap = true;
-            set_bitmapPosition(bitmapPosition);
         }
         return value;
     }


### PR DESCRIPTION
If you a had a button in a button bar, it would cause problem
```
<button-bar>
            <button text="Item 1" icon="haxeui-core/styles/default/haxeui_small.png" iconPosition="top" />
 </button-bar>
```

You would have 
```../src/common/btncmn.cpp(109): assert "!!(dir & wxLEFT) + !!(dir & wxRIGHT) + !!(dir & wxTOP) + !!(dir & wxBOTTOM) == 1" failed in SetBitmapPosition(): exactly one direction flag must be set
../src/gtk/anybutton.cpp(403): assert ""Assert failure"" failed in DoSetBitmapPosition(): invalid position
```

That's because the bitmapPosition would be set even the value is "enum(0)".

Now, the line seems quite useless, because it seems the basic buttons page in the component explorer work without.