### PR TITLE
strokePath to strokeFillPath

### DIFF
--- a/src/hx/widgets/GraphicsContext.hx
+++ b/src/hx/widgets/GraphicsContext.hx
@@ -58,6 +58,13 @@ class GraphicsContext extends GraphicsObject {
         if (fill) graphicscontextRef.ptr.fillPath(nativePath);
     }
 
+    public function strokePath(path:GraphicsPath) {
+        strokeFillPath(path, true, false);
+    }
+
+    public function fillPath(path:GraphicsPath) {
+        strokeFillPath(path, false, true);
+    }
 
     public function strokeLine(x1:Float, y1:Float, x2:Float, y2:Float) {
         graphicscontextRef.ptr.strokeLine(x1, y1, x2, y2);

--- a/src/hx/widgets/GraphicsContext.hx
+++ b/src/hx/widgets/GraphicsContext.hx
@@ -25,7 +25,7 @@ class GraphicsContext extends GraphicsObject {
     }
 
     @:access(hx.widgets.GraphicsPath)
-    public function strokePath(path:GraphicsPath) {
+    public function strokeFillPath(path:GraphicsPath, stroke:Bool = true, fill:Bool = true) {
         var nativePath = graphicscontextRef.ptr.createPath();
         for (call in path.calls) {
             switch (call) {
@@ -54,7 +54,8 @@ class GraphicsContext extends GraphicsObject {
             }
 
         }
-        graphicscontextRef.ptr.strokePath(nativePath);
+        if (stroke) graphicscontextRef.ptr.strokePath(nativePath);
+        if (fill) graphicscontextRef.ptr.fillPath(nativePath);
     }
 
 

--- a/src/wx/widgets/GraphicsContext.hx
+++ b/src/wx/widgets/GraphicsContext.hx
@@ -27,6 +27,7 @@ extern class GraphicsContext extends GraphicsObject {
     @:native("CreatePath")                      public function createPath():GraphicsPath;
     @:native("StrokePath")                      public function strokePath(path:GraphicsPath):Void;
     @:native("StrokeLine")                      public function strokeLine(x1:Float, y1:Float, x2:Float, y2:Float):Void;
+    @:native("FillPath")                        public function fillPath(path:GraphicsPath):Void;
     @:native("SetPen")                          public function setPen(pen:Pen):Void;
     @:native("SetBrush")                        public function setBrush(brush:Brush):Void;
     @:native("SetFont")                         public function setFont(font:Font, colour:Colour):Void;


### PR DESCRIPTION
I've added strokeFillPath (and fillPath)  to stoke and fill the path at the same time. As otherwise, we'll need tp create the path twice.

Kept strokePath and added fillPath, to mirror wxwidgets