### PR TITLE
Fix version checks for property types

### DIFF
--- a/src/wx/widgets/PGPropertyValuesFlags.hx
+++ b/src/wx/widgets/PGPropertyValuesFlags.hx
@@ -1,6 +1,6 @@
 package wx.widgets;
 
-#if (wxWidgetsVersion > version("3.2.4"))
+#if (wxWidgetsVersion > version("3.3.0"))
 
 @:include("wx/propgrid/propgriddefs.h")
 extern enum abstract PGPropertyValuesFlags(PGPropertyValuesFlagsImpl) {

--- a/src/wx/widgets/styles/PropertyGridAttributes.hx
+++ b/src/wx/widgets/styles/PropertyGridAttributes.hx
@@ -3,7 +3,7 @@ package wx.widgets.styles;
 // https://docs.wxwidgets.org/latest/property_8h.html#propgrid_property_attributes
 @:headerCode("#include <wx/propgrid/propgrid.h>")
 class PropertyGridAttributes {
-    #if (wxWidgetsVersion < version("3.2.3"))
+    #if (wxWidgetsVersion < version("3.3.0"))
     public static var ATTR_HINT:String                  =  untyped __cpp__("wxS(\"Hint\")");
     public static var ATTR_MAX:String                   =  untyped __cpp__("wxS(\"Max\")");
     public static var ATTR_MIN:String                   = untyped __cpp__("wxS(\"Min\")");


### PR DESCRIPTION
The wxWidgets commits that affect these types have not been released in any 3.2 releases since 3.2.4, so it seems like they will only be in 3.3.

These are the relevant wxWidgets commits:
- https://github.com/wxWidgets/wxWidgets/commit/159c3b1c6d3e1dc3686a636a9be7f6ef37b247c5
- https://github.com/wxWidgets/wxWidgets/commit/f1273ce152ff5c3d63b5070b463132cbb14979b4

These version checks came from #110 originally.