### PR TITLE
Fix linker error with some wx installs

### DIFF
--- a/src/wx/widgets/EntryMacro.hx
+++ b/src/wx/widgets/EntryMacro.hx
@@ -8,6 +8,8 @@ import sys.FileSystem;
 import sys.io.File;
 import sys.io.Process;
 
+using StringTools;
+
 typedef OSVersion = {
     var major:Int;
     var minor:Int;
@@ -65,7 +67,7 @@ class EntryMacro {
             };
 
             var config = new Process("wx-config", ["--cxxflags"]);
-            var cflags = config.stdout.readAll().toString().split("\n")[0].split(" ").map(makeFlag).join("\n");
+            var cflags = config.stdout.readAll().toString().rtrim().split(" ").map(makeFlag).join("\n");
             config.exitCode();
 
             #if WEBVIEW


### PR DESCRIPTION
With some installs, `wx-config --cxxflags` has a trailing space. This causes the following xml node to be generated:
`<compilerflag value="" />`

This breaks compilation with the following error:
```
Error: g++: warning: : linker input file unused because linking not done
g++: error: : linker input file not found: No such file or directory
```

This patch fixes that problem by removing all trailing whitespace prior to splitting on the space character.